### PR TITLE
Add duration parsing to TimeEntryFromString

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "endOfLine": "auto",
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false,
+  "experimentalTernaries": true,
+  "printWidth": 100
+}

--- a/schema/Client.ts
+++ b/schema/Client.ts
@@ -33,7 +33,7 @@ const lookupClient = (code: string) =>
       return client //
         ? E.succeed(client)
         : E.fail(new Error(`Client with code "${code}" not found`))
-    })
+    }),
   )
 
 /** Schema for a `clientId` encoded as a `code` */
@@ -43,7 +43,7 @@ export const ClientIdFromCode = S.transformOrFail(S.String, ClientId, {
       E.mapBoth({
         onFailure: e => new ParseResult.Type(ast, code, e.message),
         onSuccess: p => p.id,
-      })
+      }),
     )
   },
   encode: (clientId, options, ast) => ParseResult.succeed('TODO'),

--- a/schema/Duration.ts
+++ b/schema/Duration.ts
@@ -46,8 +46,10 @@ export const DurationFromString = S.transformOrFail(S.String, Duration, {
       return matches.map(match => accessor(match.groups as Record<string, string>))
     })
 
-    if (results.length > 1) return ParseResult.fail(new ParseResult.Type(ast, input, 'MULTIPLE_DURATIONS'))
-    if (results.length === 0) return ParseResult.fail(new ParseResult.Type(ast, input, 'NO_DURATION'))
+    if (results.length > 1)
+      return ParseResult.fail(new ParseResult.Type(ast, input, 'MULTIPLE_DURATIONS'))
+    if (results.length === 0)
+      return ParseResult.fail(new ParseResult.Type(ast, input, 'NO_DURATION'))
 
     return ParseResult.succeed({ ...results[0], input })
   },

--- a/schema/LocalDate.ts
+++ b/schema/LocalDate.ts
@@ -11,9 +11,11 @@ export const LocalDateFromString = S.transformOrFail(
       try {
         return ParseResult.succeed(LocalDate.parse(s))
       } catch (e) {
-        return ParseResult.fail(new ParseResult.Type(ast, s, `string could not be parsed as LocalDate`))
+        return ParseResult.fail(
+          new ParseResult.Type(ast, s, `string could not be parsed as LocalDate`),
+        )
       }
     },
     encode: d => ParseResult.succeed(d.toString()),
-  }
+  },
 )

--- a/schema/Project.ts
+++ b/schema/Project.ts
@@ -30,7 +30,7 @@ const lookupProject = (code: string) =>
       return project //
         ? E.succeed(project)
         : E.fail(new Error(`Project with code "${code}" not found`))
-    })
+    }),
   )
 
 /** Schema for a `projectId` encoded as a `code` */
@@ -40,7 +40,7 @@ export const ProjectIdFromCode = S.transformOrFail(S.String, ProjectId, {
       E.mapBoth({
         onFailure: e => new ParseResult.Type(ast, code, e.message),
         onSuccess: p => p.id,
-      })
+      }),
     )
   },
   encode: ParseResult.succeed,

--- a/schema/TimeEntry.ts
+++ b/schema/TimeEntry.ts
@@ -12,8 +12,10 @@ export type TimeEntryId = typeof TimeEntryId.Type
 
 export class TimeEntry extends S.Class<TimeEntry>('TimeEntry')({
   id: S.optional(TimeEntryId, { default: () => createId() as TimeEntryId }),
+  // TODO: we won't know userId and date from the input text, make them optional or create a subtype for parsing?
   userId: UserId,
   date: LocalDateFromString,
+  originalText: S.String,
   duration: S.Number,
   projectId: ProjectId,
   clientId: S.optional(ClientId),
@@ -48,6 +50,7 @@ export const TimeEntryFromString = S.transformOrFail(S.String, TimeEntry, {
       userId,
       date,
       duration: Number(duration),
+      originalText: input,
       projectId,
       clientId: clientId || undefined,
       description: description || undefined,

--- a/schema/TimeEntry.ts
+++ b/schema/TimeEntry.ts
@@ -1,11 +1,12 @@
 import { ParseResult, Schema as S } from '@effect/schema'
 import { createId } from '@paralleldrive/cuid2'
-import { pipe } from 'effect'
+import { Either, pipe } from 'effect'
 import { Cuid } from './Cuid'
 import { LocalDateFromString } from './LocalDate'
 import { ProjectId } from './Project'
 import { UserId } from './User'
 import { ClientId } from './Client'
+import { DurationFromString } from './Duration'
 
 export const TimeEntryId = pipe(Cuid, S.brand('TimeEntryId'))
 export type TimeEntryId = typeof TimeEntryId.Type
@@ -30,17 +31,30 @@ export type TimeEntryEncoded = typeof TimeEntry.Encoded
 
 export const TimeEntryFromString = S.transformOrFail(S.String, TimeEntry, {
   strict: true,
-  decode: (s, _, ast) => {
-    // bullshit implementation
-    const [userId, date, duration, projectId, clientId, description] = s.split('|')
+  decode: (input, _, ast) => {
+    let description = input
 
-    // real implementation goes here
+    // mock some values just to get start
+    const userId = '1' as UserId
+    const date = '2024-07-15'
+    const projectId: ProjectId = '' as ProjectId
 
     // find a projectId using ProjectFromString (to be written) which will use ProjectIdFromCode
 
     // find a clientId (ditto)
 
     // find a duration using DurationFromString
+    let duration: number = 0
+    const decodeDuration = S.decodeEither(DurationFromString)
+    const parsedDuration = decodeDuration(input)
+    if (Either.isLeft(parsedDuration)) {
+      return ParseResult.fail(
+        new ParseResult.Type(ast, input, parsedDuration.left.error.error.message.value),
+      )
+    } else {
+      duration = parsedDuration.right.duration
+      description = description.replace(parsedDuration.right.text, '')
+    }
 
     // strip out the project tag, the client tag, and the duration text; everything that's left is the description
 
@@ -49,11 +63,11 @@ export const TimeEntryFromString = S.transformOrFail(S.String, TimeEntry, {
     return ParseResult.succeed({
       userId,
       date,
-      duration: Number(duration),
       originalText: input,
+      duration,
       projectId,
-      clientId: clientId || undefined,
-      description: description || undefined,
+      clientId: undefined,
+      description: description.trim(),
     })
   },
   encode: (_, options, ast) => ParseResult.fail(new ParseResult.Forbidden(ast, 'cannot encode a TimeEntry')),

--- a/schema/TimeEntry.ts
+++ b/schema/TimeEntry.ts
@@ -70,5 +70,6 @@ export const TimeEntryFromString = S.transformOrFail(S.String, TimeEntry, {
       description: description.trim(),
     })
   },
-  encode: (_, options, ast) => ParseResult.fail(new ParseResult.Forbidden(ast, 'cannot encode a TimeEntry')),
+  encode: (_, options, ast) =>
+    ParseResult.fail(new ParseResult.Forbidden(ast, 'cannot encode a TimeEntry')),
 })

--- a/test/TimeEntry.test.ts
+++ b/test/TimeEntry.test.ts
@@ -8,6 +8,7 @@ import { TimeEntry, type TimeEntryEncoded } from '../schema/TimeEntry'
 describe('TimeEntry', () => {
   it('decodes TimeEntry', () => {
     const decoded = TimeEntry.decode({
+      originalText: '',
       userId: '0001',
       date: '2024-06-10',
       duration: 60,
@@ -29,6 +30,7 @@ describe('TimeEntry', () => {
 
   it('encodes TimeEntry', () => {
     const decoded = TimeEntry.decode({
+      originalText: '',
       userId: '0001',
       date: '2024-06-10',
       duration: 60,

--- a/test/TimeEntry.test.ts
+++ b/test/TimeEntry.test.ts
@@ -1,11 +1,61 @@
 import { Schema as S } from '@effect/schema'
 import { LocalDate } from '@js-joda/core'
-import { Effect as E, pipe } from 'effect'
-import { describe, expect, expectTypeOf, it } from 'vitest'
+import { Effect as E, Either, pipe } from 'effect'
+import { assert, describe, expect, expectTypeOf, it, test } from 'vitest'
 import { ProjectIdFromCode, Projects, ProjectsProvider, type Project } from '../schema/Project'
-import { TimeEntry, type TimeEntryEncoded } from '../schema/TimeEntry'
+import { TimeEntry, TimeEntryFromString, type TimeEntryEncoded } from '../schema/TimeEntry'
 
 describe('TimeEntry', () => {
+  describe('TimeEntryFromString', () => {
+    const decode = S.decodeEither(TimeEntryFromString)
+
+    const testCases: TestCase[] = [
+      {
+        input: '#Support: Ongoing @aba update geography',
+        error: 'NO_DURATION',
+      },
+      {
+        input: '1h #Support: Ongoing @aba update geography',
+        duration: 60,
+        projectId: '',
+        clientId: '',
+        description: '#Support: Ongoing @aba update geography', // needs whittled down as we parse and remove things
+      },
+    ]
+
+    for (const {
+      input,
+      error,
+      duration,
+      clientId,
+      projectId,
+      description,
+      only,
+      skip,
+    } of testCases) {
+      const testFn = only ? test.only : skip ? test.skip : test
+
+      testFn(input, () => {
+        const result = decode(input)
+        if (Either.isLeft(result)) {
+          // @ts-ignore result.left.error.error wtf
+          assert(error, `expected success but got error ${result.left.error.error.message.value}`)
+
+          // @ts-ignore
+          expect(result.left.error.error.message.value).toBe(error) // <- wtf
+        } else {
+          assert(!error, `expected error ${error}`)
+
+          const parseResult = result.right
+          // expect(parseResult.projectId).toEqual(projectId)
+          // expect(parseResult.clientId).toEqual(clientId)
+          expect(parseResult.description).toEqual(description)
+          expect(parseResult.duration).toEqual(duration)
+        }
+      })
+    }
+  })
+
   it('decodes TimeEntry', () => {
     const decoded = TimeEntry.decode({
       originalText: '',
@@ -66,3 +116,14 @@ describe('TimeEntry', () => {
     expect(projectId).toBe('0001')
   })
 })
+
+type TestCase = {
+  input: string
+  error?: string
+  duration?: number
+  projectId?: string
+  clientId?: string
+  description?: string
+  only?: boolean
+  skip?: boolean
+}

--- a/test/TimeEntry.test.ts
+++ b/test/TimeEntry.test.ts
@@ -109,7 +109,7 @@ describe('TimeEntry', () => {
       pipe(
         code, //
         S.decodeUnknown(ProjectIdFromCode),
-        E.provideService(Projects, TestProjects)
+        E.provideService(Projects, TestProjects),
       )
 
     const projectId = E.runSync(decode('out'))

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -142,7 +142,7 @@ describe('Schema', () => {
         encode({
           //@ts-expect-error
           foo: 'bar',
-        })
+        }),
       ).toThrow(/"name".*is missing/s)
     })
   })
@@ -208,7 +208,7 @@ describe('Schema', () => {
         encode({
           //@ts-expect-error
           foo: 'bar',
-        })
+        }),
       ).toThrow(/"name".*is missing/s)
     })
   })
@@ -225,11 +225,13 @@ describe('Schema', () => {
             const parsed = LocalDate.parse(s)
             return ParseResult.succeed(parsed)
           } catch (e) {
-            return ParseResult.fail(new ParseResult.Type(ast, s, `string could not be parsed as LocalDate`))
+            return ParseResult.fail(
+              new ParseResult.Type(ast, s, `string could not be parsed as LocalDate`),
+            )
           }
         },
         encode: d => ParseResult.succeed(d.toString()),
-      }
+      },
     )
 
     // Cuid is a branded String
@@ -356,7 +358,7 @@ describe('Schema', () => {
             id: 'pfh0haxfpzowht3oi213cqos',
             userId: 'tz4a98xxat96iws9zmbrgj3a',
             date: 'asdf',
-          })
+          }),
         ).toThrow(/string could not be parsed as LocalDate/i)
       })
 
@@ -367,7 +369,7 @@ describe('Schema', () => {
             userId: 'tz4a98xxat96iws9zmbrgj3a',
             date: '2024-06-10',
           },
-          S.decodeUnknownSync(TimeEntry)
+          S.decodeUnknownSync(TimeEntry),
         )
 
         //@ts-expect-error (TimeEntryId is not assignable to UserId)
@@ -435,7 +437,7 @@ describe('Schema', () => {
               return project //
                 ? E.succeed(project)
                 : E.fail(new Error(`Project with code "${code}" not found`))
-            })
+            }),
           )
 
         /** Schema for a `projectId` encoded as a `code` */
@@ -445,7 +447,7 @@ describe('Schema', () => {
               E.mapBoth({
                 onFailure: e => new ParseResult.Type(ast, code, e.message),
                 onSuccess: p => p.id,
-              })
+              }),
             )
           },
           encode: ParseResult.succeed, // unclear on this - presumably we'd want this to work in the opposite direction as well?
@@ -461,7 +463,7 @@ describe('Schema', () => {
           pipe(
             code,
             S.decodeUnknown(ProjectIdFromCode),
-            E.provideService(Projects, TestProjects)
+            E.provideService(Projects, TestProjects),
             // E.mapError(e => TreeFormatter.formatError(e))
           )
 


### PR DESCRIPTION
I started putting together a test harness similar to what we did in `Duration` and I used the `DurationFromString` schema to parse `duration` in `TimeEntryFromString`.

I think there's a little bit more nuance for `TimeEntry` that we haven't yet captured so I added the `originalText` field to `TimeEntry`. I also added a note that we won't know the `userId` or `date` from the input text but those fields are required. I'm not sure what we'll need to do to support those kinds of things. I guess a `projectId` not being present in the `originalText` would also be a problem. We want to require those things but need to support some kind of incomplete object too.